### PR TITLE
Optimize completion

### DIFF
--- a/src/Common/GitCommands.ps1
+++ b/src/Common/GitCommands.ps1
@@ -658,7 +658,10 @@ function gitCommitMessage() {
             $keyLength = $Matches['key'].Length
         }
     }
-    return __git rev-parse @refs 2>$null | ForEach-Object { $msgTable[$_.Substring(0, $keyLength)] }
+
+    foreach ($line in (__git rev-parse @refs 2>$null)) {
+        $msgTable[$line.Substring(0, $keyLength)]
+    }
 }
 
 function gitRecentLog() {

--- a/src/Complete/GitCompleteCommand.ps1
+++ b/src/Complete/GitCompleteCommand.ps1
@@ -169,12 +169,19 @@ function gitCompleteRefs {
     switch ($Mode) {
         'refs' {
             $matchRef = $false
-            gitRefs -Current $Current -Remote $Remote | ForEach-Object {
+            $refs = gitRefs -Current $Current -Remote $Remote | ForEach-Object {
                 if ($Current -ceq $_) {
                     $matchRef = $true
                 }
                 $_
-            } | completeList -Current $Current -Prefix $Prefix -Suffix $Suffix -ResultType $ResultType -WithCommitMessage:($Remote -ceq '')
+            }
+
+            $messages = $null
+            if ($Remote -ceq '') {
+                $messages = (gitCommitMessage $refs)
+            }
+
+            $refs | completeList -Current $Current -Prefix $Prefix -Suffix $Suffix -ResultType $ResultType -Messages $messages
 
             if ($Current) {
                 if ($matchRef) {

--- a/src/Complete/SubCommand/Tag.ps1
+++ b/src/Complete/SubCommand/Tag.ps1
@@ -37,7 +37,9 @@ function Complete-GitSubCommand-tag {
     }
 
     if ($deleteOrVerify) {
-        gitTags $Current | completeList -Current $Current -ResultType ParameterValue -Exclude $Used -WithCommitMessage
+        $refs = gitTags $Current
+        $messages = (gitCommitMessage $refs)
+        $refs | completeList -Current $Current -ResultType ParameterValue -Exclude $Used -Messages $messages
         return
     }
 
@@ -57,7 +59,9 @@ function Complete-GitSubCommand-tag {
 
     if ($Used.Count -eq 0) {
         if ($force) {
-            gitTags $Current | completeList -Current $Current -ResultType ParameterValue -WithCommitMessage
+            $refs = gitTags $Current
+            $messages = (gitCommitMessage $refs)
+            $refs | completeList -Current $Current -ResultType ParameterValue -Messages $messages
         }
         return
     }


### PR DESCRIPTION
## Extracted commit message retrieval into a separate function

Separated it from the cmdlet.

## Pre-fetch corresponding subcommands

Previously, alias resolution was performed every time; now it is done only when needed.
